### PR TITLE
chore(ci): bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -26,10 +26,10 @@ jobs:
       image: ghcr.io/xu-cheng/texlive-full:latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache pip packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /root/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements-build.txt') }}
@@ -46,7 +46,7 @@ jobs:
         run: jupyter-book build --pdf
 
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: jupyter-book-pdf
           path: exports/book.pdf
@@ -56,20 +56,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
       - name: Cache pip packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-html-pip-${{ hashFiles('.github/workflows/build-book.yml') }}
@@ -77,7 +77,7 @@ jobs:
             ${{ runner.os }}-html-pip-
 
       - name: Cache execution outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: _build/execute
           key: ${{ runner.os }}-execute-${{ hashFiles('myst.yml', 'features/**/*.md') }}
@@ -110,4 +110,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION

    Bump GitHub Actions to Node 24-compatible major versions in .github/workflows/build-book.yml.
    Updates:
        actions/checkout@v5
        actions/cache@v5
        actions/setup-node@v5
        actions/setup-python@v6
        actions/upload-artifact@v5
        actions/deploy-pages@v5
    Removes Node 20 deprecation warnings in build-html, build-pdf, and deploy.
    No workflow logic changes beyond action version upgrades.
